### PR TITLE
Postgres support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [org.clojure/data.csv "1.0.0"] 
                  [org.clojure/tools.cli "1.0.206"]
                  [cheshire "5.10.0"]
-                 [org.xerial/sqlite-jdbc "3.36.0"]
+                 [org.xerial/sqlite-jdbc "3.36.0"];SQLite driver
+                 [org.postgresql/postgresql "42.5.0"];PostgresSQL driver
                  [org.apache.jena/jena-core "4.4.0"]
                  [org.apache.jena/jena-arq "4.4.0"]
                  [org.apache.jena/jena-iri "4.4.0"]]

--- a/src/ldtab/cli.clj
+++ b/src/ldtab/cli.clj
@@ -19,15 +19,21 @@
 ;TODO: implement options for subcommands
 ;TODO write custom help messages for subcommands
 (def init-options
-  [["-h" "--help"]])
+  [["-h" "--help"] 
+   ["-d" "--database SYSTEM" "Connection uri"
+    :parse-fn #(identity %)]])
 
 (def prefix-options
   [["-h" "--help"]
-   ["-l" "--list" "List prefixes"]])
+   ["-l" "--list" "List prefixes"]
+   ["-d" "--database SYSTEM" "Connection uri"
+    :parse-fn #(identity %)]])
 
 (def import-options
   [["-h" "--help"]
    ["-t" "--table TABLE" "Table"
+    :parse-fn #(identity %)]
+   ["-d" "--database SYSTEM" "Connection uri"
     :parse-fn #(identity %)]
    ["-s" "--streaming"]])
 
@@ -36,6 +42,8 @@
    ["-t" "--table TABLE" "Table"
     :parse-fn #(identity %)] 
    ["-f" "--format FORMAT" "Output format"
+    :parse-fn #(identity %)]
+   ["-d" "--database SYSTEM" "Connection uri"
     :parse-fn #(identity %)]
    ["-s" "--streaming"]])
 
@@ -203,7 +211,9 @@
 ;TODO handle options for subcommand
 (defn ldtab-init
   [command]
-  (let [db (second (:arguments (parse-opts command init-options)))]
+  (let [{:keys [options arguments errors summary]} (parse-opts command import-options) 
+        db (second arguments)
+        database-system (:database options)]
    (init-db/create-database db)))
 
 ;TODO handle options for subcommend
@@ -214,14 +224,20 @@
         db (second arguments)
         ontology (nth arguments 2)
         streaming (:streaming options)
-        table (:table options)]
+        table (:table options)
+        database-system (:database options)
+
+        ;set defaults
+        table (if table table "statement")
+        database-system (if database-system database-system "sqlite")]
+
     (if streaming
       (if table
         (import-db/import-rdf-stream db table ontology "graph")
         (import-db/import-rdf-stream db ontology "graph"))
       (if table
         (import-db/import-rdf-model db table ontology "graph")
-        (import-db/import-rdf-model db ontology "graph")))));TODO how do we handle the graph input?
+        (import-db/import-rdf-model db ontology "graph")))));TODO how do we handle the graph input?  
 
 (defn ldtab-export
   [command]

--- a/src/ldtab/cli.clj
+++ b/src/ldtab/cli.clj
@@ -89,9 +89,6 @@
     (not= 2 (count arguments))
     {:exit-message "Invalid input: init requires a single argument."} 
 
-    (.exists (io/as-file (second arguments)))
-    {:exit-message (str "Invalid input: File " (second arguments) " already exists.")} 
-
     :else
     {:action command})))
 
@@ -117,9 +114,6 @@
       (not= 3 (count arguments))
       {:exit-message "Invalid input: prefix requires two arguments."} 
 
-      (not (.exists (io/as-file (second arguments))))
-      {:exit-message "Invalid input: database (first argument) does not exist."} 
-
       (not (.exists (io/as-file (nth arguments 2))))
       {:exit-message "Invalid input: prefix table (second argument) does not exist."} 
 
@@ -140,9 +134,6 @@
     (not= 3 (count arguments))
     {:exit-message "Invalid input: import requires two arguments."} 
 
-    (not (.exists (io/as-file (second arguments))))
-    {:exit-message "Invalid input: database (first argument) does not exist."} 
-
     (not (.exists (io/as-file (nth arguments 2))))
     {:exit-message "Invalid input: ontology (second argument) does not exist."} 
 
@@ -162,9 +153,6 @@
 
     (not= 3 (count arguments))
     {:exit-message "Invalid input: export requires two arguments."} 
-
-    (not (.exists (io/as-file (second arguments))))
-    {:exit-message "Invalid input: database (first argument) does not exist."} 
 
     (.exists (io/as-file (nth arguments 2)))
     {:exit-message "Invalid input: output file (second argument) already exists."} 

--- a/src/ldtab/cli.clj
+++ b/src/ldtab/cli.clj
@@ -18,23 +18,21 @@
 
 ;TODO: implement options for subcommands
 ;TODO write custom help messages for subcommands
+
 (def init-options
   [["-h" "--help"] 
-   ["-d" "--database SYSTEM" "Connection uri"
-    :parse-fn #(identity %)]])
+   ["-c" "--connection" "Database connection uri"]])
 
 (def prefix-options
   [["-h" "--help"]
    ["-l" "--list" "List prefixes"]
-   ["-d" "--database SYSTEM" "Connection uri"
-    :parse-fn #(identity %)]])
+   ["-c" "--connection" "Database connection uri"]])
 
 (def import-options
   [["-h" "--help"]
    ["-t" "--table TABLE" "Table"
     :parse-fn #(identity %)]
-   ["-d" "--database SYSTEM" "Connection uri"
-    :parse-fn #(identity %)]
+   ["-c" "--connection" "Database connection uri"]
    ["-s" "--streaming"]])
 
 (def export-options
@@ -43,8 +41,7 @@
     :parse-fn #(identity %)] 
    ["-f" "--format FORMAT" "Output format"
     :parse-fn #(identity %)]
-   ["-d" "--database SYSTEM" "Connection uri"
-    :parse-fn #(identity %)]
+   ["-c" "--connection" "Database connection uri"]
    ["-s" "--streaming"]])
 
 (defn get-file-extension
@@ -201,8 +198,10 @@
   [command]
   (let [{:keys [options arguments errors summary]} (parse-opts command import-options) 
         db (second arguments)
-        database-system (:database options)]
-   (init-db/create-database db)))
+        database-system (:connection options)] 
+        (if database-system
+          (init-db/initialise-database db);expects a connnection-uri
+          (init-db/create-sql-database db))));expects the name for the database 
 
 ;TODO handle options for subcommend
 ;TODO add options to use 'streaming' or 'non-streaming' version
@@ -213,7 +212,7 @@
         ontology (nth arguments 2)
         streaming (:streaming options)
         table (:table options)
-        database-system (:database options)
+        database-system (:connection options)
 
         ;set defaults
         table (if table table "statement")

--- a/src/ldtab/cli.clj
+++ b/src/ldtab/cli.clj
@@ -198,33 +198,34 @@
   [command]
   (let [{:keys [options arguments errors summary]} (parse-opts command import-options) 
         db (second arguments)
-        database-system (:connection options)] 
-        (if database-system
-          (init-db/initialise-database db);expects a connnection-uri
+        database-connection (:connection options)] 
+        (if database-connection
+          (init-db/initialise-database db);expects a connection-uri
           (init-db/create-sql-database db))));expects the name for the database 
 
 ;TODO handle options for subcommend
 ;TODO add options to use 'streaming' or 'non-streaming' version
 (defn ldtab-import
-  [command]
+  [command] 
   (let [{:keys [options arguments errors summary]} (parse-opts command import-options)
         db (second arguments)
         ontology (nth arguments 2)
         streaming (:streaming options)
         table (:table options)
-        database-system (:connection options)
+        database-connection (:connection options)
 
         ;set defaults
         table (if table table "statement")
-        database-system (if database-system database-system "sqlite")]
+        db-con (if database-connection
+                 db ;db is connection-uri
+                 (str "jdbc:sqlite:"
+                      (System/getProperty "user.dir")
+                      "/" db))] ;db is database name
 
+    ;'streaming' and 'in-memory' are separate implementations
     (if streaming
-      (if table
-        (import-db/import-rdf-stream db table ontology "graph")
-        (import-db/import-rdf-stream db ontology "graph"))
-      (if table
-        (import-db/import-rdf-model db table ontology "graph")
-        (import-db/import-rdf-model db ontology "graph")))));TODO how do we handle the graph input?  
+        (import-db/import-rdf-stream db-con table ontology "graph")
+        (import-db/import-rdf-model db-con table ontology "graph"))))
 
 (defn ldtab-export
   [command]

--- a/src/ldtab/init.clj
+++ b/src/ldtab/init.clj
@@ -1,18 +1,9 @@
 (ns ldtab.init
   (:require [clojure.java.jdbc :as jdbc]))
 
-(defn create-database
-  "Creates an SQLite file with three tables:
-  1. 'ldtab' with columns: [key, value],
-  2. 'prefix' with columns: [prefix, base],
-  3. 'statement' with columns: [assertion, retraction, graph, subject, predicate, object, datatype, annotation]." 
-  [dbname] 
-  (let [db-spec {:dbtype "sqlite"
-                 :dbname (str dbname) 
-                 :user "myaccount"
-                 :password "secret"}
-
-        metadata-table-ddl (jdbc/create-table-ddl :ldtab
+(defn setup
+  [db-spec]
+  (let [metadata-table-ddl (jdbc/create-table-ddl :ldtab
                                                   [[:key "TEXT" "PRIMARY KEY"]
                                                    [:value "TEXT"]])
 
@@ -37,3 +28,21 @@
 
     (jdbc/insert! db-spec :ldtab {:key "ldtab version" :value "0.0.1"})
     (jdbc/insert! db-spec :ldtab {:key "schema version" :value "0"})))
+
+;example: {:connection-uri "jdbc:postgresql://127.0.0.1:5432/kdb?user=knocean&password=knocean"} 
+(defn initialise-database
+  [connection]
+  (let [db-spec {:connection-uri connection}]
+    (setup db-spec))) 
+
+(defn create-sql-database
+  "Creates an SQLite file with three tables:
+  1. 'ldtab' with columns: [key, value],
+  2. 'prefix' with columns: [prefix, base],
+  3. 'statement' with columns: [assertion, retraction, graph, subject, predicate, object, datatype, annotation]." 
+  [dbname] 
+  (let [db-spec {:dbtype "sqlite"
+                 :dbname (str dbname)
+                 :user "myaccount"
+                 :password "secret"}]
+    (setup db-spec)))

--- a/src/ldtab/prefix.clj
+++ b/src/ldtab/prefix.clj
@@ -11,33 +11,27 @@
   (doall
     (csv/read-csv reader :separator \tab)))) 
 
-(defn load-db
-  [path]
-  {:classname "org.sqlite.JDBC"
-  :subprotocol "sqlite"
-  :subname path})
-
 (defn insert-prefix
   [db prefix base]
   (jdbc/insert! db :prefix {:prefix prefix :base base}))
 
 (defn query-prefixes
-  [db-path]
-  (let [db (load-db db-path)]
+  [db-connection-uri]
+  (let [db {:connection-uri db-connection-uri}]
     (jdbc/query db ["SELECT * FROM prefix"])))
 
 (defn get-prefixes-as-string
   "Query for prefixes in an SQLite database and return them as a string."
-  [db-path]
-  (let [prefixes (query-prefixes db-path)
+  [db-connection-uri]
+  (let [prefixes (query-prefixes db-connection-uri)
         prefix-strings (map #(str (:prefix %) "," (:base %) "\n") prefixes)
         prefix-string (str/join prefix-strings)] 
-    (str "Prefixes in " db-path ":\n\n" prefix-string))) 
+    (str "Prefixes in " db-connection-uri ":\n\n" prefix-string))) 
 
 (defn insert-prefixes
   "Add prefixes from a TSV file to an SQLite database."
- [db-path prefixes-path]
- (let [db (load-db db-path)
+ [db-connection-uri prefixes-path]
+ (let [db {:connection-uri db-connection-uri}
        prefixes (rest (parse-tsv prefixes-path))];rest: drop header "prefix base"
    (doseq [p prefixes] 
      (insert-prefix db (first p) (second p)))))

--- a/test/ldtab/thin2thick_test.clj
+++ b/test/ldtab/thin2thick_test.clj
@@ -1,0 +1,104 @@
+(ns ldtab.thin2thick-test
+  (:require [clojure.test :refer :all] 
+            [cheshire.core :as cs]
+            [ldtab.thin2thick :as t2t ])) 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;Check that thick-triples can be compared as strings;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest key-order-is-different-after-parsing
+  (let [s1 "{\"owl:onProperty\":[{\"datatype\":\"_IRI\",\"object\":\"obo:RO_0000085\"}],
+             \"owl:someValuesFrom\":[{\"datatype\":\"_IRI\",\"object\":\"obo:OBI_0001043\"}],
+             \"rdf:type\":[{\"datatype\":\"_IRI\",\"object\":\"owl:Restriction\"}]}"
+        s2 "{\"owl:someValuesFrom\":[{\"datatype\":\"_IRI\",\"object\":\"obo:OBI_0001043\"}],
+             \"owl:onProperty\":[{\"datatype\":\"_IRI\",\"object\":\"obo:RO_0000085\"}],
+             \"rdf:type\":[{\"datatype\":\"_IRI\",\"object\":\"owl:Restriction\"}]}"
+
+        json1 (cs/parse-string s1 true)
+        json2 (cs/parse-string s2 true) 
+
+        ss1 (str json1)
+        ss2 (str json2)]
+    (is (not= ss1 ss2))))
+
+(deftest key-order-is-the-same-after-sorting
+  (let [s1 "{\"owl:onProperty\":[{\"datatype\":\"_IRI\",\"object\":\"obo:RO_0000085\"}],
+             \"owl:someValuesFrom\":[{\"datatype\":\"_IRI\",\"object\":\"obo:OBI_0001043\"}],
+             \"rdf:type\":[{\"datatype\":\"_IRI\",\"object\":\"owl:Restriction\"}]}"
+        s2 "{\"owl:someValuesFrom\":[{\"datatype\":\"_IRI\",\"object\":\"obo:OBI_0001043\"}],
+             \"owl:onProperty\":[{\"datatype\":\"_IRI\",\"object\":\"obo:RO_0000085\"}],
+             \"rdf:type\":[{\"datatype\":\"_IRI\",\"object\":\"owl:Restriction\"}]}"
+        json1 (cs/parse-string s1 true)
+        json2 (cs/parse-string s2 true)
+
+        sort1 (t2t/sort-json json1)
+        sort2 (t2t/sort-json json2)
+
+        ss1 (str sort1)
+        ss2 (str sort2)]
+    (is ss1 ss2)))
+
+
+(deftest array-order-is-different-after-parsing
+  (let [s1 "{\"obo:IAO_0010000\":[{\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-001\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-002\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-003\"}]}"
+        s2 "{\"obo:IAO_0010000\":[{\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-003\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-001\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-002\"}]}"
+
+        json1 (cs/parse-string s1 true)
+        json2 (cs/parse-string s2 true)] 
+    (is (not= json1 json2))))
+
+(deftest array-order-is-the-same-after-sorting
+  (let [s1 "{\"obo:IAO_0010000\":[{\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-001\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-002\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-003\"}]}"
+        s2 "{\"obo:IAO_0010000\":[{\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-003\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-001\"},
+                    {\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-002\"}]}"
+
+        json1 (cs/parse-string s1 true)
+        json2 (cs/parse-string s2 true)
+
+        sort1 (t2t/sort-json json1)
+        sort2 (t2t/sort-json json2)
+        
+        ss1 (str sort1)
+        ss2 (str sort2)] 
+    (is ss1 ss2)))
+
+(deftest array-order-and-key-order-is-the-same-after-sorting
+  (let [s1 "{\"owl:onProperty\":[{\"datatype\":\"_IRI\",\"object\":\"obo:RO_0000085\"}],
+             \"owl:someValuesFrom\":[{\"datatype\":\"_IRI\",\"object\":\"obo:OBI_0001043\"}],
+             \"rdf:type\":[{\"datatype\":\"_IRI\",\"object\":\"owl:Restriction\"}],
+             \"obo:IAO_0010000\":[{\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-001\"},
+                                 {\"datatype\":\"_IRI\",
+                                  \"object\":\"obo:bfo/axiom/033-002\",
+                                  \"meta\":\"owl:Axiom\"},
+                                 {\"datatype\":\"_IRI\",
+                                  \"meta\":\"owl:Axiom\",
+                                  \"object\":\"obo:bfo/axiom/033-003\"}]}"
+
+        s2 "{\"owl:someValuesFrom\":[{\"datatype\":\"_IRI\",\"object\":\"obo:OBI_0001043\"}],
+             \"owl:onProperty\":[{\"datatype\":\"_IRI\",\"object\":\"obo:RO_0000085\"}],
+             \"rdf:type\":[{\"datatype\":\"_IRI\",\"object\":\"owl:Restriction\"}], 
+             \"obo:IAO_0010000\":[{\"datatype\":\"_IRI\",\"meta\":\"owl:Axiom\",\"object\":\"obo:bfo/axiom/033-003\"},
+                                  {\"datatype\":\"_IRI\",
+                                   \"meta\":\"owl:Axiom\",
+                                   \"object\":\"obo:bfo/axiom/033-001\"},
+                                  {\"meta\":\"owl:Axiom\",
+                                   \"datatype\":\"_IRI\",
+                                   \"object\":\"obo:bfo/axiom/033-002\"}]}"
+
+        json1 (cs/parse-string s1 true)
+        json2 (cs/parse-string s2 true)
+
+        sort1 (t2t/sort-json json1)
+        sort2 (t2t/sort-json json2)
+        
+        ss1 (str sort1)
+        ss2 (str sort2)] 
+    (is ss1 ss2)))


### PR DESCRIPTION
LDTab can now connect to other database systems, e.g., postgres, via a connection URI.

The default for LDTab commands is still SQLite. So, `import ex.db ontology.owl` assumes `ex.db` is an SQLite database.
To connect to other databases, option `-c` needs to be set and a connection URI to the database needs to be specified.
For example, the command `import -c jdbc:postgresql://127.0.0.1:5432/kdb?user=knocean&password=secret ontology.owl` instructs LDTab to connect to a local postgres database `kdb` as user `knocean` with password `secret` to import `ontology.owl`.

The option `-c` to connect to a database via a connection URI can be used with all four commands available in LDTab, i.e., `init`, `prefix`, `import`, and `export`.
  