### PR TITLE
Use longest matching prefix

### DIFF
--- a/src/ldtab/thin2thick.clj
+++ b/src/ldtab/thin2thick.clj
@@ -19,11 +19,12 @@
 
 (defn curify-with
   [uri iri2prefix]
-  (let [found (first (filter #(str/starts-with? uri (:base %)) iri2prefix))]
+  (let [matches (filter #(str/starts-with? uri (:base %)) iri2prefix)
+        sorted (sort-by #(count (:base %)) matches) ;sort by length
+        found (last sorted)] ;get longest match
     (if found
       (str/replace uri (:base found) (str (:prefix found) ":"))
       (str "<" uri ">"))))
-
 
 (defn map-on-hash-map-vals
   "Given a hashmap m and a function f, 


### PR DESCRIPTION
The longest matching prefix should be used in  [curify-with](https://github.com/ontodev/ldtab.clj/blob/main/src/ldtab/thin2thick.clj#L20) to turn an IRI into a CURIE.