### PR TITLE
Fix duplicated values (fixes #28)

### DIFF
--- a/src/ldtab/thin2thick.clj
+++ b/src/ldtab/thin2thick.clj
@@ -216,7 +216,9 @@
   "Given a set of thin triples,
     return a map from subjects to thin triples."
   [thin-triples]
-  (group-by (fn [^Triple x] (.getSubject x)) thin-triples))
+  (let [grouping (group-by (fn [^Triple x] (.getSubject x)) thin-triples)
+        dedup (map-on-hash-map-vals distinct grouping)]
+    dedup))
 
 (defn thin-2-thick-triple-raw
   "Given a root thin triple t (see function root-triples) and a map from subjects to thin triples in an RDF graph G,


### PR DESCRIPTION
Jena's internal model doesn't treat an RDF graph as a **set** of triples. Instead, repeated triples (meaning triples with the same subject, predicate, and object) are represented as different Java objects, even though they are the same w.r.t. [equals](https://jena.apache.org/documentation/javadoc/jena/org.apache.jena.core/org/apache/jena/graph/Triple.html#equals(java.lang.Object)). It seems that Jena's internal model repeats triples for blank nodes annotated with `rdf:nodeID="genid3"`, leading to duplicates in our LDTab output.

The proposed change fixes this issue. However, it would prevent us from round-tripping files with duplicate triples. This is not exactly desirable. I'll see whether I can come up with a better solution. At least we know where the 'bug' is located.